### PR TITLE
Create cloudkit service account

### DIFF
--- a/cluster-scope/overlays/hypershift1/fulfillment-aap/clusterrolebinding.yaml
+++ b/cluster-scope/overlays/hypershift1/fulfillment-aap/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  namespace: fulfillment-aap
+  name: cloudkit-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cloudkit-sa
+    namespace: fulfillment-aap

--- a/cluster-scope/overlays/hypershift1/fulfillment-aap/kustomization.yaml
+++ b/cluster-scope/overlays/hypershift1/fulfillment-aap/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - ansibleautomationplatform.yaml
+- serviceaccount.yaml
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/hypershift1/fulfillment-aap/serviceaccount.yaml
+++ b/cluster-scope/overlays/hypershift1/fulfillment-aap/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudkit-sa
+  namespace: fulfillment-aap


### PR DESCRIPTION
This service account will be used by AAP in order to create the k8s
resources in the cluster.

We give the admin rights to this user for the moment in order to move
forward with the playbooks, but we will restraints its rights once we
figure out a better model.
