### PR TITLE
Adding minio configuration to hypershift1

### DIFF
--- a/minio/overlays/hypershift1/externalsecrets/patch-minio-admin-credentials.yaml
+++ b/minio/overlays/hypershift1/externalsecrets/patch-minio-admin-credentials.yaml
@@ -1,0 +1,12 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-admin-credentials
+  namespace: minio
+spec:
+  secretStoreRef:
+    name: nerc-cluster-secrets
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: nerc/hypershift1/minio/minio-admin-credentials

--- a/minio/overlays/hypershift1/files/minio-config.env
+++ b/minio/overlays/hypershift1/files/minio-config.env
@@ -1,0 +1,1 @@
+# Documentation: https://min.io/docs/minio/linux/reference/minio-server/settings/iam/openid.html

--- a/minio/overlays/hypershift1/kustomization.yaml
+++ b/minio/overlays/hypershift1/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+
+configMapGenerator:
+- name: minio-config
+  namespace: minio
+  envs:
+  - files/minio-config.env
+
+patches:
+  - path: externalsecrets/patch-minio-admin-credentials.yaml
+  - path: persistentvolumeclaims/patch-pvc.yaml

--- a/minio/overlays/hypershift1/persistentvolumeclaims/patch-pvc.yaml
+++ b/minio/overlays/hypershift1/persistentvolumeclaims/patch-pvc.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  resources:
+    requests:
+      storage: 20Ti


### PR DESCRIPTION
Minio will be used for ACM Observability of managed clusters, and Open
Telemetry for AI workloads.
